### PR TITLE
Run docker with a temp volume

### DIFF
--- a/scripts/tgrade/start.sh
+++ b/scripts/tgrade/start.sh
@@ -25,4 +25,4 @@ docker run --rm \
   --mount type=bind,source="$SCRIPT_DIR/template",target=/template \
   --mount type=volume,source=tgrade_data,target=/root \
   "$REPOSITORY:$VERSION" \
-  tgrade start --trace --home=/template/node0/tgrade 2>&1 | grep 'executed block'
+  /bin/sh -c "cp -r /template/node0/tgrade /root; tgrade start --trace --home=/root/tgrade 2>&1 | grep 'executed block'"


### PR DESCRIPTION
Closes #10.

Instead of using the mounted template folder to run the tgrade app a copy is used so that the host dir is not modified
