### PR TITLE
Remove text from T-Market

### DIFF
--- a/src/App/pages/TMarket/index.tsx
+++ b/src/App/pages/TMarket/index.tsx
@@ -2,25 +2,18 @@ import Stack from "App/components/Stack/style";
 import IssueTokenModal from "App/containers/IssueTokenModal";
 import { useState } from "react";
 import TMarket from "./routes";
-import { LightButton, LinkText, PageWrapper, Text, Title, TitleWrapper } from "./style";
+import { LightButton, PageWrapper, Title, TitleWrapper } from "./style";
 
 export default function TMarketHome(): JSX.Element | null {
   const [isModalOpen, setModalOpen] = useState(false);
 
   return (
     <PageWrapper>
-      <Stack>
+      <Stack gap="s4">
         <TitleWrapper>
           <Title>Welcome to T-Market</Title>
           <LightButton onClick={() => setModalOpen(true)}>Create Asset</LightButton>
         </TitleWrapper>
-        <Text>
-          T-Market is an Automated Market Maker (AMM) which is constantly running and will always give a price
-          for the listed pairs.
-        </Text>
-        <LinkText href="https://confio.github.io/tgrade-docs/docs/onboarding/T-Market/">
-          What is T-market?
-        </LinkText>
         <TMarket />
       </Stack>
       <IssueTokenModal isModalOpen={isModalOpen} closeModal={() => setModalOpen(false)} />

--- a/src/App/pages/TMarket/style.ts
+++ b/src/App/pages/TMarket/style.ts
@@ -46,28 +46,3 @@ export const LightButton = Styled(Button)`
   color: var(--color-primary);
   background-color: white;
 `;
-
-export const LinkText = Styled.a`
-left: 264px;
-top: 116px;
-font-family: Quicksand;
-font-style: normal;
-font-weight: 500;
-font-size: 16px;
-line-height: 20px;
-
-color: #0BB0B1;
-&:onHover{
-    cursor:pointer;
-}
-`;
-
-export const Text = Styled.p`
-left: 264px;
-top: 82px;
-font-family: Quicksand;
-font-style: normal;
-font-weight: normal;
-font-size: 16px;
-line-height: 28px;
-color: #242730;`;


### PR DESCRIPTION
Removes this text from the T-Market page, between title and exchange component:
![image](https://user-images.githubusercontent.com/44572727/134664619-73f22c8c-9e92-410c-a913-1f25c6f5b93c.png)