### PR TITLE
Add config for staging deployment

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -8,6 +8,9 @@
         "internal": [
           "tgrade-internal"
         ],
+        "staging": [
+          "tgrade-staging"
+        ],
         "public": [
           "tgrade-public"
         ]

--- a/firebase.json
+++ b/firebase.json
@@ -26,6 +26,31 @@
       ]
     },
     {
+      "target": "staging",
+      "public": "build",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "headers": [
+        {
+          "source": "**",
+          "headers": [{ "key": "Cache-Control", "value": "max-age=60" }]
+        },
+        {
+          "source": "static/**",
+          "headers": [{ "key": "Cache-Control", "value": "max-age=31536000" }]
+        }
+      ]
+    },
+    {
       "target": "public",
       "public": "build",
       "ignore": [

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "deploy:branch": "netlify deploy --dir=build --alias=$(git branch --show-current)",
     "deploy": "netlify deploy --dir=build --prod",
     "deploy:internal": "firebase deploy --only hosting:internal",
+    "deploy:staging": "firebase deploy --only hosting:staging",
     "deploy:public": "firebase deploy --only hosting:public",
     "test": "craco test",
     "lint": "npx eslint src/**/*.ts{,x} --max-warnings 0",


### PR DESCRIPTION
With `yarn deploy:staging` you can now deploy the `./build` result to https://staging.tgrade.finance/

See https://github.com/confio/tgrade-testnets/issues/20