### PR TITLE
Add explicit command to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run: yarn compile
       - run:
           name: Webpack build
-          command: yarn build
+          command: yarn build:local
           no_output_timeout: 5m
 
   lint:


### PR DESCRIPTION
CI runs `yarn build` but now the commands are explicit about the network.