### PR TITLE
Bump tgrade version to v0.5.1

### DIFF
--- a/scripts/tgrade/env
+++ b/scripts/tgrade/env
@@ -1,5 +1,5 @@
 # Choose from https://hub.docker.com/r/confio/tgrade/tags
 REPOSITORY="confio/tgrade"
-VERSION="v0.5.0"
+VERSION="v0.5.1"
 
 CONTAINER_NAME="tgrade"


### PR DESCRIPTION
Upgrade docker version.

Includes tgrade-contracts [v0.5.1](https://github.com/confio/tgrade-contracts/releases/tag/v0.5.1)
