### PR TITLE
Provide dynamic fee values to ExtraInfo components

### DIFF
--- a/src/App/pages/TMarket/routes/exchange/components/ExtraInfo/index.tsx
+++ b/src/App/pages/TMarket/routes/exchange/components/ExtraInfo/index.tsx
@@ -1,15 +1,19 @@
+import { StdFee } from "@cosmjs/stargate";
 import { Col } from "antd";
 import InfoRow from "App/components/InfoRow";
 import { useFormikContext } from "formik";
-import { useSdk } from "service";
 import { useExchange } from "service/exchange";
 import { SwapFormValues } from "utils/tokens";
 
+import { formatTgdFee } from "../../utils/fees";
 import Divider from "./style";
 
-const ExtraInfo = (): JSX.Element | null => {
+interface ExtraInfoProps {
+  readonly fee: StdFee;
+}
+
+const ExtraInfo = ({ fee }: ExtraInfoProps): JSX.Element | null => {
   const { exchangeState } = useExchange();
-  const { sdkState } = useSdk();
   const { values } = useFormikContext<SwapFormValues>();
   const { simulatedSwap } = exchangeState;
 
@@ -20,7 +24,6 @@ const ExtraInfo = (): JSX.Element | null => {
   const LiquidityProviderFee = PrettyNumber(
     (Number(values.From) / Number(values.To)) * Number(simulatedSwap.commission_amount),
   );
-  const fee = PrettyNumber(Number(sdkState.config.gasPrice.amount) / 2);
 
   //Tootips:
   const tooltips = {
@@ -47,7 +50,7 @@ const ExtraInfo = (): JSX.Element | null => {
           value={`${LiquidityProviderFee} ${values.selectFrom?.symbol}`}
           tooltip={tooltips.liquidityProviderFee}
         />
-        <InfoRow label="Tx Fee" value={`${fee} TGD`} tooltip={tooltips.txFee} />
+        <InfoRow label="Tx Fee" value={formatTgdFee(fee)} tooltip={tooltips.txFee} />
       </Col>
       <Divider />
     </>

--- a/src/App/pages/TMarket/routes/exchange/index.tsx
+++ b/src/App/pages/TMarket/routes/exchange/index.tsx
@@ -1,3 +1,4 @@
+import { calculateFee } from "@cosmjs/stargate";
 import { Divider } from "antd";
 import {
   EstimatedMessage,
@@ -24,6 +25,7 @@ import {
   useExchange,
 } from "service/exchange";
 import { updateToken, useTMarket } from "service/tmarket";
+import { Token } from "utils/tokens";
 import { DetailSwap, PairProps, SimulatedSwap, SwapFormValues, TokenProps } from "utils/tokens";
 
 import { ExtraInfo, FromToken, ToToken } from "./components";
@@ -105,7 +107,7 @@ export default function Exchange(): JSX.Element {
             </MiddleRow>
             <ToToken />
             <Divider />
-            <ExtraInfo />
+            <ExtraInfo fee={calculateFee(Token.GAS_SWAP, sdkState.config.gasPrice)} />
             <EstimatedMessage />
             <SubmitButton
               disabled={

--- a/src/App/pages/TMarket/routes/exchange/utils/fees.ts
+++ b/src/App/pages/TMarket/routes/exchange/utils/fees.ts
@@ -1,0 +1,18 @@
+import { Decimal } from "@cosmjs/math";
+import { StdFee } from "@cosmjs/stargate";
+
+/**
+ * Creates a user friendly string representation of a utgd fee, such as "0.025 TGD".
+ *
+ * Note this is for displaying purposes only and can remove precision. E.g.
+ * { amount: "333333", denom: "utgd" } becomes "0.3333 TGD".
+ */
+export function formatTgdFee(fee: StdFee): string {
+  if (fee.amount.length !== 1) throw new Error("Only one coin supported in fee display");
+  const coin = fee.amount[0];
+  if (coin.denom !== "utgd") throw new Error("Only utgd denom supported");
+  const [whole, fractional] = Decimal.fromAtomics(coin.amount, 6).toString().split(".");
+  // Makes a large number with to many decimals shorter by truncating
+  // Ex 0.0238454945350234 => 0.0238
+  return `${whole}.${fractional.slice(0, 4)} TGD`;
+}

--- a/src/App/pages/TMarket/routes/provide/components/ExtraInfo/index.tsx
+++ b/src/App/pages/TMarket/routes/provide/components/ExtraInfo/index.tsx
@@ -1,3 +1,4 @@
+import { StdFee } from "@cosmjs/stargate";
 import { Col } from "antd";
 import InfoRow from "App/components/InfoRow";
 import { useFormikContext } from "formik";
@@ -5,12 +6,17 @@ import { useSdk } from "service";
 import { useProvide } from "service/provide";
 import { ProvideFormValues } from "utils/tokens";
 
+import { formatTgdFee } from "../../../exchange/utils/fees";
 import Divider from "./style";
 
-const ExtraInfo = (): JSX.Element | null => {
+interface ExtraInfoProps {
+  readonly fee: StdFee;
+}
+
+const ExtraInfo = ({ fee }: ExtraInfoProps): JSX.Element | null => {
   const { provideState } = useProvide();
   const { sdkState } = useSdk();
-  const { client, config } = sdkState;
+  const { client } = sdkState;
   const { values } = useFormikContext<ProvideFormValues>();
   const { extraInfo } = provideState;
 
@@ -76,7 +82,7 @@ const ExtraInfo = (): JSX.Element | null => {
         />
         <InfoRow
           label={`Tx fee`}
-          value={`${config.gasPrice.amount} ${config.gasPrice.denom}`}
+          value={formatTgdFee(fee)}
           tooltip={"The Tx fee is an amount charged by miners for processing your transactions."}
         />
       </Col>

--- a/src/App/pages/TMarket/routes/provide/index.tsx
+++ b/src/App/pages/TMarket/routes/provide/index.tsx
@@ -1,3 +1,4 @@
+import { calculateFee } from "@cosmjs/stargate";
 import { Divider } from "antd";
 import {
   EstimatedMessage,
@@ -26,7 +27,14 @@ import {
   useProvide,
 } from "service/provide";
 import { updatePairs, updateToken, useTMarket } from "service/tmarket";
-import { DetailProvide, PairProps, ProvideFormValues, SimulationProvide, TokenProps } from "utils/tokens";
+import {
+  DetailProvide,
+  PairProps,
+  ProvideFormValues,
+  SimulationProvide,
+  Token,
+  TokenProps,
+} from "utils/tokens";
 
 import { ApproveTokensRow, EmptyPoolTip, ExtraInfo, FromToken, ToToken } from "./components";
 import ProvideResultModal from "./components/ProvideResultModal";
@@ -131,7 +139,7 @@ export default function Provide(): JSX.Element {
             <ToToken />
             <Divider />
             <EmptyPoolTip />
-            <ExtraInfo />
+            <ExtraInfo fee={calculateFee(Token.GAS_PROVIDE_LIQUIDITY, config.gasPrice)} />
             <ApproveTokensRow />
             <EstimatedMessage />
             <SubmitButton

--- a/src/App/pages/TMarket/routes/withdraw/components/ExtraInfo/index.tsx
+++ b/src/App/pages/TMarket/routes/withdraw/components/ExtraInfo/index.tsx
@@ -1,20 +1,23 @@
+import { StdFee } from "@cosmjs/stargate";
 import { Col } from "antd";
 import InfoRow from "App/components/InfoRow";
 import { useFormikContext } from "formik";
-import { useSdk } from "service";
 import { useWithdraw } from "service/withdraw";
 import { SwapFormValues } from "utils/tokens";
 
+import { formatTgdFee } from "../../../exchange/utils/fees";
 import Divider from "./style";
 
-const ExtraInfo = (): JSX.Element | null => {
+interface ExtraInfoProps {
+  readonly fee: StdFee;
+}
+
+const ExtraInfo = ({ fee }: ExtraInfoProps): JSX.Element | null => {
   const { withdrawState } = useWithdraw();
-  const { sdkState } = useSdk();
   const { values } = useFormikContext<SwapFormValues>();
   const { detail } = withdrawState;
 
   if (!detail || !values.From || !values.selectFrom) return null;
-  const fee = PrettyNumber(Number(sdkState.config.gasPrice.amount) / 2);
 
   const tooltips = {
     poolAfter: "Contribution percentage to the pool",
@@ -27,7 +30,7 @@ const ExtraInfo = (): JSX.Element | null => {
         <InfoRow label="Price Impact" value={`${detail.priceImpact} %`} />
         <InfoRow label="LP after Tx" value={`${detail.lpAfter}`} />
         <InfoRow label="Pool Share after Tx" value={`${detail.sharePool}`} tooltip={tooltips.poolAfter} />
-        <InfoRow label="Tx Fee" value={`${fee}`} tooltip={tooltips.txFee} />
+        <InfoRow label="Tx Fee" value={formatTgdFee(fee)} tooltip={tooltips.txFee} />
       </Col>
       <Divider />
     </>
@@ -35,10 +38,3 @@ const ExtraInfo = (): JSX.Element | null => {
 };
 
 export default ExtraInfo;
-
-//Makes a large number with to many decimals shorter
-//Ex 0.0238454945350234 => 0.0238
-const PrettyNumber = (largeNumber: string | number): number => {
-  const number = Number(largeNumber);
-  return number <= 0 ? 0 : parseFloat(number.toFixed(4));
-};

--- a/src/App/pages/TMarket/routes/withdraw/index.tsx
+++ b/src/App/pages/TMarket/routes/withdraw/index.tsx
@@ -1,3 +1,4 @@
+import { calculateFee } from "@cosmjs/stargate";
 import { Divider } from "antd";
 import {
   ArrowIcon,
@@ -14,7 +15,7 @@ import { useHistory, useRouteMatch } from "react-router-dom";
 import { useSdk } from "service";
 import { updateLPToken, useTMarket } from "service/tmarket";
 import { setDetailWithdraw, setLoading, setWithdrawButtonState, useWithdraw } from "service/withdraw";
-import { DetailWithdraw, LPToken, WithdrawFormValues } from "utils/tokens";
+import { DetailWithdraw, LPToken, Token, WithdrawFormValues } from "utils/tokens";
 
 import { FromToken, ToToken } from "./components";
 import ExtraInfo from "./components/ExtraInfo";
@@ -82,7 +83,7 @@ export default function Withdraw(): JSX.Element {
             </MiddleRow>
             <ToToken />
             <Divider />
-            <ExtraInfo />
+            <ExtraInfo fee={calculateFee(Token.GAS_WITHDRAW_LIQUIDITY, config.gasPrice)} />
             <EstimatedMessage />
             <SubmitButton
               disabled={errors.to !== undefined || errors.from !== undefined}


### PR DESCRIPTION
The conversion `Number(sdkState.config.gasPrice.amount) / 2` only works as long as the gas limit is exactly 500_000. With this change, the fee is provided to the UI component as an `StdFee` that is calculated thhe exact same way as the transaction fee later on. This allows us to adjust the gas limit and change the value in ExtraInfo automatically. It also prepares a transition to dynamically calculated fee estimations via simulation.

As you can see in `formatTgdFee`, we don't need to convert to floats (numbers) in between whcih improves the precision of the value.