### PR TITLE
Only slashing fix

### DIFF
--- a/src/App/components/OcCreateProposalModal/components/ProposalPunishValidator/index.tsx
+++ b/src/App/components/OcCreateProposalModal/components/ProposalPunishValidator/index.tsx
@@ -65,9 +65,6 @@ export default function ProposalPunishValidator({
       const jailTime = jailedForever
         ? "forever"
         : { duration: Number.isNaN(dateToSeconds) ? 0 : dateToSeconds };
-      console.log({ jailTime });
-      console.log({ jailedTo });
-      console.log({ nativePortion });
 
       const transactionHash = await dsoContract.propose(address, comment, {
         punish: {


### PR DESCRIPTION
Fixes issue "message index: 0: Error parsing into type tgrade_oc_proposals::msg::ExecuteMsg: Invalid number.: execute wasm contract failed" when creating proposal to only slash but not jail.