### PR TITLE
Support longer addresses

### DIFF
--- a/src/App/components/AddDsoModal/components/FormDsoAddExisting/index.tsx
+++ b/src/App/components/AddDsoModal/components/FormDsoAddExisting/index.tsx
@@ -42,7 +42,7 @@ export default function FormDsoAddExisting({
       })
       .test(`has-valid-length`, `Trusted Circle address must have a data length of 20`, (address) => {
         const decodedAddress = getDecodedAddress(address);
-        return decodedAddress?.data.length === 20;
+        return !!decodedAddress?.data && decodedAddress.data.length >= 20;
       }),
   });
 

--- a/src/utils/forms.ts
+++ b/src/utils/forms.ts
@@ -33,7 +33,7 @@ export function getAddressField(t: TFunction, addressPrefix: string, optional = 
     })
     .test(`has-valid-length`, t("form.address.length"), (address) => {
       const decodedAddress = getDecodedAddress(address);
-      return decodedAddress?.data.length === 20;
+      return !!decodedAddress?.data && decodedAddress.data.length >= 20;
     });
 }
 
@@ -50,7 +50,7 @@ export function isValidAddress(address: string, requiredPrefix: string): boolean
     if (prefix !== requiredPrefix) {
       return false;
     }
-    return data.length === 20;
+    return data.length >= 20;
   } catch {
     return false;
   }


### PR DESCRIPTION
The new tgrade binary generates addresses with a data length of 32, so I changed form validation from `===20` to `>=20`.