### PR TITLE
make Cypress job optional in Circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,11 +192,11 @@ workflows:
       - test:
           # https://circleci.com/docs/2.0/env-vars/
           context: Testing-Env-Vars
-      - hold: # <<< A job that will require manual approval in the CircleCI web application.
+      - run Cypress?: # <<< A job that will require manual approval in the CircleCI web application.
           type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
       - cypress:
           requires:
-            - hold
+            - run Cypress?
       - build:
           requires:
             - lint


### PR DESCRIPTION
This PR is about to make cypress job optional
docs https://circleci.com/docs/2.0/sample-config/
before
![image](https://user-images.githubusercontent.com/13170022/155396631-936cd185-fed0-4a20-abfa-0c561261b5f6.png)


after
![image](https://user-images.githubusercontent.com/13170022/155396491-99600947-f5eb-4f07-8eef-cbacc7f81e56.png)
