### PR TITLE
Load contracts pagination

### DIFF
--- a/src/utils/cw20.ts
+++ b/src/utils/cw20.ts
@@ -236,10 +236,21 @@ export class Contract20WS {
       await Promise.all([cw20TokensAddressesPromise, tgradeCw20AddressesPromise])
     ).flat();
 
+    // Get batched token infos
+    const tokensInfos: TokenProps[] = [];
+
+    while (tokensInfos.length < tokenAddresses.length) {
+      console.log({ tokensInfoslength: tokensInfos.length });
+      const nextTokensInfos = await Promise.all(
+        tokenAddresses
+          .slice(tokensInfos.length, 300 + tokensInfos.length)
+          .map((address) => this.getTokenInfo(client, clientAddress, address, config)),
+      );
+
+      tokensInfos.unshift(...nextTokensInfos);
+    }
+
     // Fill map with tokens info
-    const tokensInfos = await Promise.all(
-      tokenAddresses.map((address) => this.getTokenInfo(client, clientAddress, address, config)),
-    );
     tokensInfos.forEach((tokenInfo) => {
       tokensMap[tokenInfo.address] = tokenInfo;
     });


### PR DESCRIPTION
Uses inner queryclient function to circumvent this [CosmJs issue](https://github.com/cosmos/cosmjs/blob/main/packages/cosmwasm-stargate/src/cosmwasmclient.ts#L338), in order to get all of the contracts and not just the first 100.

Also gets token infos in 300 element batches so that the network does not run out of resources.