### PR TITLE
Bump tgrade version

### DIFF
--- a/scripts/tgrade/env
+++ b/scripts/tgrade/env
@@ -1,5 +1,5 @@
 # Choose from https://hub.docker.com/r/confio/tgrade/tags
 REPOSITORY="confio/tgrade"
-VERSION="v0.8.0-beta2"
+VERSION="v0.8.0"
 
 CONTAINER_NAME="tgrade"


### PR DESCRIPTION
Bump to [v0.8.0](https://github.com/confio/tgrade/releases/tag/v0.8.0)