### PR TITLE
Fix flaky "Create TC" test

### DIFF
--- a/cypress/integration/tradingPair.ts
+++ b/cypress/integration/tradingPair.ts
@@ -26,7 +26,7 @@ describe("Trading Pair", () => {
   });
 
   describe("Create Trusted circle", () => {
-    beforeEach(() => {
+    before(() => {
       cy.findByText(/Add Trusted Circle/i).click();
       cy.findByText(/Create Trusted Circle/i).click();
       cy.findByPlaceholderText(/Enter Trusted Circle name/i)


### PR DESCRIPTION
based on failure it looks like, cypress clicks very quickly on `Go to ...` button and there is not enough time to close this message
![image](https://user-images.githubusercontent.com/13170022/162387098-415a2fae-43ec-411f-bb4a-a75594ef8f2d.png)
