### PR TITLE
Extend configuration of "deploy_contracts.mjs" to run on localhost

### DIFF
--- a/scripts/tgrade/deploy_contracts.mjs
+++ b/scripts/tgrade/deploy_contracts.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 /*jshint esversion: 8 */
 
-/* eslint-disable @typescript-eslint/naming-convention */
 import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { Bip39, Random } from "@cosmjs/crypto";
 import { FaucetClient } from "@cosmjs/faucet-client";

--- a/scripts/tgrade/init_testnet.sh
+++ b/scripts/tgrade/init_testnet.sh
@@ -5,7 +5,7 @@ command -v shellcheck >/dev/null && shellcheck "$0"
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 
 # Deploy contracts
-"$SCRIPT_DIR/deploy_contracts.mjs"
+"$SCRIPT_DIR/deploy_contracts.mjs" network
 # Query and load validator voting contract's address
 VALIDATOR_VOTING_ADDRESS="$(curl https://lcd.dryrunnet.tgrade.confio.run/tgrade/poe/v1beta1/contract/VALIDATOR_VOTING | jq -r '.address')"
 # Instantiate factory with validator voting contract's address as migrator

--- a/scripts/tgrade/instantiate_factory.mjs
+++ b/scripts/tgrade/instantiate_factory.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 /*jshint esversion: 8 */
 
-/* eslint-disable @typescript-eslint/naming-convention */
 import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { Bip39, Random } from "@cosmjs/crypto";
 import { FaucetClient } from "@cosmjs/faucet-client";


### PR DESCRIPTION
This PR is about to revert back the ability to deploy contracts on localhost
by adding back
```
const localConfig = {
  endpoint: "http://localhost:26657",
  faucet: "http://localhost:8000",
  bech32prefix: "tgrade",
  feeDenom: "utgd",
  gasPrice: GasPrice.fromString("0.05utgd"),
};
```