### PR TITLE
Remove option to Copy/Past address for "Tgrade token"

### DIFF
--- a/src/App/pages/TMarket/components/SelecTokenModal/components/ListTokens/index.tsx
+++ b/src/App/pages/TMarket/components/SelecTokenModal/components/ListTokens/index.tsx
@@ -61,14 +61,18 @@ export default function ListTokens({ tokensList, setToken, closeModal }: ListTok
             <ContainerNumbersPin>
               <ContainerNumbers>
                 <Paragraph>{token.humanBalance}</Paragraph>
-                <Paragraph
-                  onClick={(event) => {
-                    event?.stopPropagation();
-                  }}
-                  copyable={{ tooltips: "Copy token address" }}
-                >
-                  {token.address === config.feeToken ? "Tgrade token" : token.address}
-                </Paragraph>
+                {token.address !== config.feeToken ? (
+                  <Paragraph
+                    onClick={(event) => {
+                      event?.stopPropagation();
+                    }}
+                    copyable={{ tooltips: "Copy token address" }}
+                  >
+                    {token.address}
+                  </Paragraph>
+                ) : (
+                  <Paragraph>{"Tgrade token"}</Paragraph>
+                )}
               </ContainerNumbers>
               {token.address !== config.feeToken ? (
                 <img


### PR DESCRIPTION
Remove option to Copy/Past address for "Tgrade token"
closes: [#540](https://github.com/confio/tgrade-app/issues/540)

**Before**
![image](https://user-images.githubusercontent.com/13170022/163406751-2564ad08-2a9f-4b0b-b3b6-bf2e7f4ae744.png)

**After**
![image](https://user-images.githubusercontent.com/13170022/163406913-12a0191c-6895-43ce-8564-2cd2d691c282.png)
