### PR TITLE
Fix decimals on token creation

### DIFF
--- a/src/App/containers/IssueTokenForm/index.tsx
+++ b/src/App/containers/IssueTokenForm/index.tsx
@@ -63,9 +63,6 @@ export default function IssueTokenForm({ setTxResult, closeModal }: IssueTokenFo
 
     try {
       const decimalsNumber = parseInt(decimals, 10);
-      const amount = Decimal.fromUserInput(initialSupply, decimalsNumber)
-        .multiply(Uint64.fromNumber(10 ** decimalsNumber))
-        .toString();
       const cap = mintCap
         ? Decimal.fromUserInput(mintCap, decimalsNumber)
             .multiply(Uint64.fromNumber(10 ** decimalsNumber))
@@ -88,7 +85,7 @@ export default function IssueTokenForm({ setTxResult, closeModal }: IssueTokenFo
         tokenName,
         tokenSymbol,
         decimalsNumber,
-        [{ address, amount }],
+        [{ address, amount: initialSupply }],
         minter,
         marketing,
         values.dsoAddress,


### PR DESCRIPTION
When creating a digital asset the specified initial supply was transformed into a decimal so the decimal digits were applied twice.