### PR TITLE
Freeze @cosmjs/stargate release version 0.28.1 (for Digital Ocean)

### DIFF
--- a/scripts/remote_start.sh
+++ b/scripts/remote_start.sh
@@ -34,7 +34,7 @@ scp -r ./scripts/* "$REMOTE:~/scripts"
 # ssh "$REMOTE" "ls -lA ~/scripts"
 
 echo "Install npm dependencies for deployment scripts …"
-ssh -t "$REMOTE" "npm install @cosmjs/stargate@0.28.4 @cosmjs/proto-signing@0.28.4 @cosmjs/faucet-client@0.28.4 @cosmjs/crypto@0.28.4 @cosmjs/cosmwasm-stargate@0.28.4"
+ssh -t "$REMOTE" "npm install @cosmjs/stargate@0.28.1 @cosmjs/proto-signing@0.28.1 @cosmjs/faucet-client@0.28.1 @cosmjs/crypto@0.28.1 @cosmjs/cosmwasm-stargate@0.28.1"
 
 echo "Starting/restarting chain and faucet …"
 ssh -t "$REMOTE" "./scripts/stop_all.sh"


### PR DESCRIPTION
Recently we have had an issue with some dependencies, maybe we can also update the `main` branch

```
Install npm dependencies for deployment scripts …
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @cosmjs/proto-signing@0.28.6.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget 
npm ERR! notarget It was specified as a dependency of '@cosmjs/cosmwasm-stargate'
npm ERR! notarget 

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2022-06-09T05_51_44_262Z-debug.log
Connection to 159.89.11.7 closed.
⋊> ~/W/tgrade-app-type-fix on main ⨯    
```

Thank you Abel for the solution `ssh -t "$REMOTE" "npm install @cosmjs/stargate@0.28.4 @cosmjs/proto-signing@0.28.4 @cosmjs/faucet-client@0.28.4 @cosmjs/crypto@0.28.4 @cosmjs/cosmwasm-stargate@0.28.4"`