### PR TITLE
Redirect bad tmarket url to exchange

### DIFF
--- a/src/App/pages/TMarket/routes/index.tsx
+++ b/src/App/pages/TMarket/routes/index.tsx
@@ -31,7 +31,7 @@ export default function TMarket(): JSX.Element {
           <Withdraw />
         </WithdrawProvider>
       </Route>
-      <Route exact path={paths.tmarket.prefix}>
+      <Route path={paths.tmarket.prefix}>
         <Redirect to={`${paths.tmarket.prefix}${paths.tmarket.exchange.prefix}`} />
       </Route>
     </Switch>


### PR DESCRIPTION
Follow up to #509.

It does not add a 404 to T-Market since it should redirect to exchange